### PR TITLE
Fix Emergency Contacts Not Showing up in Direct Boot Mode

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -178,6 +178,12 @@
         </provider>
 
         <provider
+            android:name=".provider.EmergencyContactProvider"
+            android:authorities="com.android.emergency.contacts"
+            android:directBootAware="true"
+            android:exported="false" />
+
+        <provider
             android:name=".EmergencyGestureContentProvider"
             android:authorities="com.android.emergency.gesture"
             android:permission="android.permission.CALL_PRIVILEGED"/>

--- a/src/com/android/emergency/EmergencyContactManager.java
+++ b/src/com/android/emergency/EmergencyContactManager.java
@@ -20,9 +20,12 @@ import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+
+import com.android.emergency.provider.EmergencyContactProvider;
 import com.android.internal.logging.MetricsLogger;
 import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
 import android.net.Uri;
+import android.os.UserManager;
 import android.provider.ContactsContract;
 import android.util.Log;
 
@@ -43,16 +46,15 @@ public class EmergencyContactManager {
         String phoneType = null;
         String name = null;
         Bitmap photo = null;
-        final Uri contactLookupUri =
-                ContactsContract.Contacts.getLookupUri(context.getContentResolver(),
-                        phoneUri);
+        Uri contactLookupUri = null;
         Cursor cursor = context.getContentResolver().query(
                 phoneUri,
                 new String[]{ContactsContract.Contacts.DISPLAY_NAME,
                         ContactsContract.CommonDataKinds.Phone.NUMBER,
                         ContactsContract.CommonDataKinds.Phone.TYPE,
                         ContactsContract.CommonDataKinds.Phone.LABEL,
-                        ContactsContract.CommonDataKinds.Photo.PHOTO_ID},
+                        ContactsContract.CommonDataKinds.Photo.PHOTO_ID,
+                        ContactsContract.Contacts.LOOKUP_KEY},
                 null, null, null);
         try {
             if (cursor.moveToNext()) {
@@ -63,6 +65,7 @@ public class EmergencyContactManager {
                         cursor.getInt(2),
                         cursor.getString(3)).toString();
                 Long photoId = cursor.getLong(4);
+                contactLookupUri = Uri.parse(cursor.getString(5));
                 if (photoId != null && photoId > 0) {
                     Uri photoUri = ContentUris.withAppendedId(ContactsContract.Data.CONTENT_URI,
                             photoId);
@@ -71,7 +74,7 @@ public class EmergencyContactManager {
                             new String[]{ContactsContract.Contacts.Photo.PHOTO},
                             null, null, null);
                     try {
-                        if (cursor2.moveToNext()) {
+                        if (cursor2 != null && cursor2.moveToNext()) {
                             byte[] data = cursor2.getBlob(0);
                             if (data != null) {
                                 photo = BitmapFactory.decodeStream(new ByteArrayInputStream(data));
@@ -94,7 +97,39 @@ public class EmergencyContactManager {
 
     /** Returns whether the phone uri is not null and corresponds to an existing phone number. */
     public static boolean isValidEmergencyContact(Context context, Uri phoneUri) {
-        return phoneUri != null && phoneExists(context, phoneUri);
+        Cursor cursor = null;
+        Uri contactUri = null;
+        if (phoneUri == null) {
+            return false;
+        }
+        try {
+            cursor = context.getContentResolver().query(phoneUri, new String[]{
+                    EmergencyContactProvider.CONTACT_URI_COLUMN}, null, null, null);
+            if (cursor != null && cursor.moveToFirst()) {
+                // If the contact exists inside of the EmergencyContacts database,
+                // find the contactLookupUri to make sure it is still a valid contact
+                contactUri = Uri.parse(cursor.getString(0));
+            } else {
+                // If the contact does not exist inside of the EmergencyContacts database,
+                // it's definitely not valid
+                return false;
+            }
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        // Avoid looking up the contact in direct boot mode, as the ContactProvider is
+        // not direct boot aware
+        if (!isUserUnlocked(context)) {
+            return true;
+        }
+        return contactUri != null && phoneExists(context, contactUri);
+    }
+
+    private static boolean isUserUnlocked(Context context) {
+        UserManager userManager = context.getSystemService(UserManager.class);
+        return userManager != null && userManager.isUserUnlocked();
     }
 
     private static boolean phoneExists(Context context, Uri phoneUri) {
@@ -157,7 +192,8 @@ public class EmergencyContactManager {
         }
 
         /**
-         * The phone uri as defined in ContactsContract.CommonDataKinds.Phone.CONTENT_URI. Use
+         * The phone uri is used to query a database containing the phone number, the name, the phone type, the photo,
+         * the ContactsContract.CommonDataKinds.Phone.CONTENT_URI, and the CONTENT_LOOKUP_URI. Use
          * this to reload the contact. This links to a particular phone number of the emergency
          * contact.
          */

--- a/src/com/android/emergency/preferences/EmergencyContactsPreference.java
+++ b/src/com/android/emergency/preferences/EmergencyContactsPreference.java
@@ -15,15 +15,20 @@
  */
 package com.android.emergency.preferences;
 
+import android.content.ContentValues;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.TypedArray;
+import android.database.Cursor;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import android.os.UserManager;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceManager;
+
+import android.provider.ContactsContract;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.widget.Toast;
@@ -31,13 +36,13 @@ import android.widget.Toast;
 import com.android.emergency.EmergencyContactManager;
 import com.android.emergency.R;
 import com.android.emergency.ReloadablePreferenceInterface;
+import com.android.emergency.provider.EmergencyContactProvider;
 import com.android.emergency.util.PreferenceUtils;
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.internal.logging.MetricsLogger;
 import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -45,7 +50,8 @@ import java.util.regex.Pattern;
 /**
  * Custom {@link PreferenceCategory} that deals with contacts being deleted from the contacts app.
  *
- * <p>Contacts are stored internally using their ContactsContract.CommonDataKinds.Phone.CONTENT_URI.
+ * <p>Contacts are stored internally using their emergencyContactPhoneUri, which contains a link to
+ * their ContactsContract.CommonDataKinds.Phone.CONTENT_URI, among other things.
  */
 public class EmergencyContactsPreference extends PreferenceCategory
         implements ReloadablePreferenceInterface,
@@ -64,7 +70,7 @@ public class EmergencyContactsPreference extends PreferenceCategory
 
     private final ContactValidator mContactValidator;
     private final ContactPreference.ContactFactory mContactFactory;
-    /** Stores the emergency contact's ContactsContract.CommonDataKinds.Phone.CONTENT_URI */
+    /** Stores the emergency contact's emergencyContactPhoneUri  */
     private List<Uri> mEmergencyContacts = new ArrayList<Uri>();
     private boolean mEmergencyContactsSet = false;
 
@@ -132,22 +138,127 @@ public class EmergencyContactsPreference extends PreferenceCategory
         }
     }
 
+    private ContentValues createContentValuesFromContactsUri(Uri contactsPhoneUri) {
+        // Extract values from original contact
+        ContentValues values = null;
+        Cursor cursor = getContext().getContentResolver().query(
+                contactsPhoneUri,
+                new String[]{ContactsContract.Contacts._ID,
+                        ContactsContract.Contacts.DISPLAY_NAME,
+                        ContactsContract.CommonDataKinds.Phone.NUMBER,
+                        ContactsContract.CommonDataKinds.Phone.TYPE,
+                        ContactsContract.CommonDataKinds.Phone.LABEL,
+                        ContactsContract.CommonDataKinds.Photo.PHOTO_ID},
+                null, null, null);
+
+        if (cursor == null) {
+            return null;
+        }
+
+        try {
+            if (cursor.moveToNext()) {
+                int id = cursor.getInt(0);
+                String name = cursor.getString(1);
+                String phoneNumber = cursor.getString(2);
+                int type = cursor.getInt(3);
+                String label = cursor.getString(4);
+                Long photoId = cursor.getLong(5);
+                Uri contactLookupUri = ContactsContract.Contacts.getLookupUri(getContext().getContentResolver(), contactsPhoneUri);
+                String contactLookup = String.valueOf(contactLookupUri);
+                String uriAsString = String.valueOf(contactsPhoneUri);
+
+                values = new ContentValues();
+                values.put(ContactsContract.Contacts._ID, id);
+                values.put(ContactsContract.Contacts.DISPLAY_NAME, name);
+                values.put(ContactsContract.CommonDataKinds.Phone.NUMBER, phoneNumber);
+                values.put(ContactsContract.CommonDataKinds.Phone.TYPE, type);
+                values.put(ContactsContract.CommonDataKinds.Phone.LABEL, label);
+                values.put(ContactsContract.CommonDataKinds.Photo.PHOTO_ID, photoId);
+                values.put(ContactsContract.Contacts.LOOKUP_KEY, contactLookup);
+                values.put(EmergencyContactProvider.CONTACT_URI_COLUMN, uriAsString);
+            }
+        } finally {
+            cursor.close();
+        }
+        return values;
+    }
+
+    private ContentValues createContentValuesFromEmergencyContactsUri(Uri contactsPhoneUri) {
+        // Extract values from original contact
+        ContentValues values = null;
+        Cursor cursor = getContext().getContentResolver().query(
+                contactsPhoneUri,
+                new String[]{ContactsContract.Contacts._ID,
+                        ContactsContract.Contacts.DISPLAY_NAME,
+                        ContactsContract.CommonDataKinds.Phone.NUMBER,
+                        ContactsContract.CommonDataKinds.Phone.TYPE,
+                        ContactsContract.CommonDataKinds.Phone.LABEL,
+                        ContactsContract.CommonDataKinds.Photo.PHOTO_ID,
+                        ContactsContract.Contacts.LOOKUP_KEY,
+                        EmergencyContactProvider.CONTACT_URI_COLUMN},
+                null, null, null);
+
+        if (cursor == null) {
+            return null;
+        }
+
+        try {
+            if (cursor.moveToNext()) {
+                int id = cursor.getInt(0);
+                String name = cursor.getString(1);
+                String phoneNumber = cursor.getString(2);
+                int type = cursor.getInt(3);
+                String label = cursor.getString(4);
+                Long photoId = cursor.getLong(5);
+                String contactLookup = cursor.getString(6);
+                String uriAsString = cursor.getString(7);
+
+                values = new ContentValues();
+                values.put(ContactsContract.Contacts._ID, id);
+                values.put(ContactsContract.Contacts.DISPLAY_NAME, name);
+                values.put(ContactsContract.CommonDataKinds.Phone.NUMBER, phoneNumber);
+                values.put(ContactsContract.CommonDataKinds.Phone.TYPE, type);
+                values.put(ContactsContract.CommonDataKinds.Phone.LABEL, label);
+                values.put(ContactsContract.CommonDataKinds.Photo.PHOTO_ID, photoId);
+                values.put(ContactsContract.Contacts.LOOKUP_KEY, contactLookup);
+                values.put(EmergencyContactProvider.CONTACT_URI_COLUMN, uriAsString);
+            }
+        } finally {
+            cursor.close();
+        }
+        return values;
+    }
+
     /**
      * Adds a new emergency contact. The {@code phoneUri} is the
      * ContactsContract.CommonDataKinds.Phone.CONTENT_URI corresponding to the
      * contact's selected phone number.
      */
-    public void addNewEmergencyContact(Uri phoneUri) {
-        if (mEmergencyContacts.contains(phoneUri)) {
+    public void addNewEmergencyContact(Uri contactsPhoneUri) {
+        // The contactsPhoneUri comes from the Contacts app, so it is a
+        // ContactsContract.CommonDataKinds.Phone.CONTENT_URI. We change it to be
+        // an emergencyContactsPhoneUri.
+
+        ContentValues values = createContentValuesFromContactsUri(contactsPhoneUri);
+        if (values == null) {
+            // This means that we could not look up the contact
             return;
         }
-        if (!mContactValidator.isValidEmergencyContact(getContext(), phoneUri)) {
+
+        Uri eContactsPhoneUri = Uri.withAppendedPath(EmergencyContactProvider.AUTHORITY_URI, values.getAsString(ContactsContract.Contacts._ID));
+        if (mEmergencyContacts.contains(eContactsPhoneUri)) {
+            return;
+        }
+
+        getContext().getContentResolver().insert(eContactsPhoneUri, values);
+
+        if (!mContactValidator.isValidEmergencyContact(getContext(), eContactsPhoneUri)) {
             Toast.makeText(getContext(), getContext().getString(R.string.fail_add_contact),
                 Toast.LENGTH_LONG).show();
             return;
         }
         List<Uri> updatedContacts = new ArrayList<Uri>(mEmergencyContacts);
-        if (updatedContacts.add(phoneUri) && callChangeListener(updatedContacts)) {
+        if (updatedContacts.add(eContactsPhoneUri) && callChangeListener(updatedContacts)) {
             MetricsLogger.action(getContext(), MetricsEvent.ACTION_ADD_EMERGENCY_CONTACT);
             setEmergencyContacts(updatedContacts);
         }
@@ -158,8 +269,30 @@ public class EmergencyContactsPreference extends PreferenceCategory
         return mEmergencyContacts;
     }
 
+    public void updateEmergencyContactsDatabase(List<Uri> oldEmergencyContacts) {
+        for (Uri eContactPhoneUri : oldEmergencyContacts) {
+            if (!mEmergencyContacts.contains(eContactPhoneUri)) {
+                getContext().getContentResolver().delete(eContactPhoneUri, null, null);
+            } else if (isUserUnlocked(getContext())) {
+                ContentValues old_data = createContentValuesFromEmergencyContactsUri(eContactPhoneUri);
+                // Will only be null if the query fails, which means that it doesn't exist in the database
+                if (old_data != null) {
+                    ContentValues new_data = createContentValuesFromContactsUri(Uri.parse(
+                            old_data.getAsString(EmergencyContactProvider.CONTACT_URI_COLUMN)));
+                    if (!old_data.equals(new_data)) {
+                        getContext().getContentResolver().update(eContactPhoneUri, new_data, null,
+                                null);
+                    }
+                } else {
+                    // TODO: log
+                }
+            }
+        }
+    }
+
     public void setEmergencyContacts(List<Uri> emergencyContacts) {
         final boolean changed = !mEmergencyContacts.equals(emergencyContacts);
+        List<Uri> oldEmergencyContacts = new ArrayList<Uri>(mEmergencyContacts);
         if (changed || !mEmergencyContactsSet) {
             mEmergencyContacts = emergencyContacts;
             mEmergencyContactsSet = true;
@@ -168,6 +301,7 @@ public class EmergencyContactsPreference extends PreferenceCategory
                 notifyChanged();
             }
         }
+        updateEmergencyContactsDatabase(oldEmergencyContacts);
 
         while (getPreferenceCount() - emergencyContacts.size() > 0) {
             removePreference(getPreference(0));
@@ -290,13 +424,19 @@ public class EmergencyContactsPreference extends PreferenceCategory
     private static List<Uri> deserializeAndFilter(String key, Context context,
                                                   String emergencyContactString,
                                                   ContactValidator contactValidator) {
+        if (TextUtils.isEmpty(emergencyContactString)) {
+            return new ArrayList<Uri>(0);
+        }
         String[] emergencyContactsArray =
                 emergencyContactString.split(QUOTE_CONTACT_SEPARATOR);
         List<Uri> filteredEmergencyContacts = new ArrayList<Uri>(emergencyContactsArray.length);
+        List<Uri> emergencyContactsToRemove = new ArrayList<Uri>(emergencyContactsArray.length);
         for (String emergencyContact : emergencyContactsArray) {
             Uri phoneUri = Uri.parse(emergencyContact);
             if (contactValidator.isValidEmergencyContact(context, phoneUri)) {
                 filteredEmergencyContacts.add(phoneUri);
+            } else {
+                emergencyContactsToRemove.add(phoneUri);
             }
         }
         // If not all contacts were added, then we need to overwrite the emergency contacts stored
@@ -309,6 +449,12 @@ public class EmergencyContactsPreference extends PreferenceCategory
                 SharedPreferences sharedPreferences =
                         PreferenceManager.getDefaultSharedPreferences(context);
                 sharedPreferences.edit().putString(key, emergencyContactStrings).commit();
+
+                // Go through and remove the invalid emergency contacts from the emergency
+                // contacts database
+                for (Uri emergencyContact : emergencyContactsToRemove) {
+                    context.getContentResolver().delete(emergencyContact, null);
+                }
             }
         }
         return filteredEmergencyContacts;
@@ -318,5 +464,4 @@ public class EmergencyContactsPreference extends PreferenceCategory
         UserManager userManager = context.getSystemService(UserManager.class);
         return userManager != null && userManager.isUserUnlocked();
     }
-
 }

--- a/src/com/android/emergency/preferences/EmergencyContactsPreference.java
+++ b/src/com/android/emergency/preferences/EmergencyContactsPreference.java
@@ -234,7 +234,7 @@ public class EmergencyContactsPreference extends PreferenceCategory
      * ContactsContract.CommonDataKinds.Phone.CONTENT_URI corresponding to the
      * contact's selected phone number.
      */
-    public void addNewEmergencyContact(Uri contactsPhoneUri) {
+    public Uri addNewEmergencyContact(Uri contactsPhoneUri) {
         // The contactsPhoneUri comes from the Contacts app, so it is a
         // ContactsContract.CommonDataKinds.Phone.CONTENT_URI. We change it to be
         // an emergencyContactsPhoneUri.
@@ -242,12 +242,16 @@ public class EmergencyContactsPreference extends PreferenceCategory
         ContentValues values = createContentValuesFromContactsUri(contactsPhoneUri);
         if (values == null) {
             // This means that we could not look up the contact
-            return;
+            return null;
         }
 
-        Uri eContactsPhoneUri = Uri.withAppendedPath(EmergencyContactProvider.AUTHORITY_URI, values.getAsString(ContactsContract.Contacts._ID));
+        Uri eContactsPhoneUri = Uri.withAppendedPath(
+                EmergencyContactProvider.AUTHORITY_URI,
+                "data/"+values.getAsString(ContactsContract.Contacts._ID)
+        );
+
         if (mEmergencyContacts.contains(eContactsPhoneUri)) {
-            return;
+            return null;
         }
 
         getContext().getContentResolver().insert(eContactsPhoneUri, values);
@@ -255,13 +259,15 @@ public class EmergencyContactsPreference extends PreferenceCategory
         if (!mContactValidator.isValidEmergencyContact(getContext(), eContactsPhoneUri)) {
             Toast.makeText(getContext(), getContext().getString(R.string.fail_add_contact),
                 Toast.LENGTH_LONG).show();
-            return;
+            return null;
         }
         List<Uri> updatedContacts = new ArrayList<Uri>(mEmergencyContacts);
         if (updatedContacts.add(eContactsPhoneUri) && callChangeListener(updatedContacts)) {
             MetricsLogger.action(getContext(), MetricsEvent.ACTION_ADD_EMERGENCY_CONTACT);
             setEmergencyContacts(updatedContacts);
         }
+
+        return eContactsPhoneUri;
     }
 
     @VisibleForTesting
@@ -269,9 +275,9 @@ public class EmergencyContactsPreference extends PreferenceCategory
         return mEmergencyContacts;
     }
 
-    public void updateEmergencyContactsDatabase(List<Uri> oldEmergencyContacts) {
-        for (Uri eContactPhoneUri : oldEmergencyContacts) {
-            if (!mEmergencyContacts.contains(eContactPhoneUri)) {
+    public void updateEmergencyContactsDatabase(List<Uri> emergencyContacts) {
+        for (Uri eContactPhoneUri : mEmergencyContacts) {
+            if (!emergencyContacts.contains(eContactPhoneUri)) {
                 getContext().getContentResolver().delete(eContactPhoneUri, null, null);
             } else if (isUserUnlocked(getContext())) {
                 ContentValues old_data = createContentValuesFromEmergencyContactsUri(eContactPhoneUri);
@@ -284,15 +290,32 @@ public class EmergencyContactsPreference extends PreferenceCategory
                                 null);
                     }
                 } else {
-                    // TODO: log
+                    Log.w(TAG, "Stale Emergency Contact already deleted");
                 }
+            }
+        }
+
+        // migration implementation: prior to the emergencycontact database was implemented,
+        // emergencycontacts were stored as a comma-separated persisted string of all the
+        // Contact App URIs selected as emergency contacts. This converts those URIs to
+        // EmergencyContact App URIs and adds them to the EmergencyContact database
+        for (int i = 0; i < emergencyContacts.size(); i++) {
+            Uri phoneUri = emergencyContacts.get(i);
+            if (!phoneUri.getAuthority().equals(ContactsContract.AUTHORITY)) {
+                continue;
+            }
+
+            Uri eContactPhoneUri = addNewEmergencyContact(phoneUri);
+            if (eContactPhoneUri != null) {
+                emergencyContacts.set(i, eContactPhoneUri);
             }
         }
     }
 
     public void setEmergencyContacts(List<Uri> emergencyContacts) {
+        updateEmergencyContactsDatabase(emergencyContacts);
+
         final boolean changed = !mEmergencyContacts.equals(emergencyContacts);
-        List<Uri> oldEmergencyContacts = new ArrayList<Uri>(mEmergencyContacts);
         if (changed || !mEmergencyContactsSet) {
             mEmergencyContacts = emergencyContacts;
             mEmergencyContactsSet = true;
@@ -301,7 +324,7 @@ public class EmergencyContactsPreference extends PreferenceCategory
                 notifyChanged();
             }
         }
-        updateEmergencyContactsDatabase(oldEmergencyContacts);
+
 
         while (getPreferenceCount() - emergencyContacts.size() > 0) {
             removePreference(getPreference(0));
@@ -310,7 +333,7 @@ public class EmergencyContactsPreference extends PreferenceCategory
         // Reload the preferences or add new ones if necessary
         Iterator<Uri> it = emergencyContacts.iterator();
         int i = 0;
-        Uri phoneUri = null;
+        Uri phoneUri;
         List<Uri> updatedEmergencyContacts = null;
         while (it.hasNext()) {
             ContactPreference contactPreference = null;

--- a/src/com/android/emergency/provider/EmergencyContactDatabaseHelper.java
+++ b/src/com/android/emergency/provider/EmergencyContactDatabaseHelper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.emergency.provider;
+
+import static android.platform.uiautomatorhelpers.DeviceHelpers.getContext;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.provider.ContactsContract;
+import android.database.Cursor;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import android.net.Uri;
+import android.text.TextUtils;
+
+import com.android.emergency.PreferenceKeys;
+import com.android.emergency.preferences.*;
+import android.preference.*;
+
+import androidx.preference.PreferenceManager;
+
+import java.util.Calendar;
+
+/**
+ * Helper class for opening the database from multiple providers.  Also provides
+ * some common functionality.
+ */
+class EmergencyContactDatabaseHelper extends SQLiteOpenHelper {
+    /**
+     * Original Emergency Contact Database.
+     **/
+    private static final int VERSION_1 = 1;
+
+    // Database and table names
+    static final String DATABASE_NAME = "emergencycontacts.db";
+    static final String EMERGENCY_CONTACTS_TABLE_NAME = "emergency_contacts_tables";
+    static final String CONTACT_URI = "contact_uri";
+
+    private static void createEmergencyContactsTable(SQLiteDatabase db) {
+//        db.execSQL("DROP TABLE IF EXISTS " + EMERGENCY_CONTACTS_TABLE_NAME + ";");
+        db.execSQL("CREATE TABLE " + EMERGENCY_CONTACTS_TABLE_NAME + " (" +
+                ContactsContract.Contacts._ID + " INTEGER PRIMARY KEY, " +
+                ContactsContract.Contacts.DISPLAY_NAME + " TEXT, " +
+                ContactsContract.CommonDataKinds.Phone.NUMBER + " TEXT NOT NULL, " +
+                ContactsContract.CommonDataKinds.Phone.TYPE + " INTEGER NOT NULL, " +
+                ContactsContract.CommonDataKinds.Phone.LABEL + " TEXT, " +
+                ContactsContract.CommonDataKinds.Photo.PHOTO_ID + " INTEGER, " +
+                ContactsContract.Contacts.LOOKUP_KEY + " TEXT, " +
+                CONTACT_URI + " TEXT NOT NULL" +
+                ");");
+
+//        LogUtils.i("Alarms Table created");
+    }
+
+    public EmergencyContactDatabaseHelper(Context context) {
+        super(context, DATABASE_NAME, null, VERSION_1);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        createEmergencyContactsTable(db);
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int currentVersion) {}
+}

--- a/src/com/android/emergency/provider/EmergencyContactDatabaseHelper.java
+++ b/src/com/android/emergency/provider/EmergencyContactDatabaseHelper.java
@@ -16,26 +16,10 @@
 
 package com.android.emergency.provider;
 
-import static android.platform.uiautomatorhelpers.DeviceHelpers.getContext;
-
-import android.content.ContentValues;
 import android.content.Context;
-import android.content.SharedPreferences;
-import android.provider.ContactsContract;
-import android.database.Cursor;
-import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.net.Uri;
-import android.text.TextUtils;
-
-import com.android.emergency.PreferenceKeys;
-import com.android.emergency.preferences.*;
-import android.preference.*;
-
-import androidx.preference.PreferenceManager;
-
-import java.util.Calendar;
+import android.provider.ContactsContract;
 
 /**
  * Helper class for opening the database from multiple providers.  Also provides
@@ -49,7 +33,7 @@ class EmergencyContactDatabaseHelper extends SQLiteOpenHelper {
 
     // Database and table names
     static final String DATABASE_NAME = "emergencycontacts.db";
-    static final String EMERGENCY_CONTACTS_TABLE_NAME = "emergency_contacts_tables";
+    static final String EMERGENCY_CONTACTS_TABLE_NAME = "data";
     static final String CONTACT_URI = "contact_uri";
 
     private static void createEmergencyContactsTable(SQLiteDatabase db) {

--- a/src/com/android/emergency/provider/EmergencyContactDatabaseHelper.java
+++ b/src/com/android/emergency/provider/EmergencyContactDatabaseHelper.java
@@ -53,7 +53,6 @@ class EmergencyContactDatabaseHelper extends SQLiteOpenHelper {
     static final String CONTACT_URI = "contact_uri";
 
     private static void createEmergencyContactsTable(SQLiteDatabase db) {
-//        db.execSQL("DROP TABLE IF EXISTS " + EMERGENCY_CONTACTS_TABLE_NAME + ";");
         db.execSQL("CREATE TABLE " + EMERGENCY_CONTACTS_TABLE_NAME + " (" +
                 ContactsContract.Contacts._ID + " INTEGER PRIMARY KEY, " +
                 ContactsContract.Contacts.DISPLAY_NAME + " TEXT, " +
@@ -64,8 +63,6 @@ class EmergencyContactDatabaseHelper extends SQLiteOpenHelper {
                 ContactsContract.Contacts.LOOKUP_KEY + " TEXT, " +
                 CONTACT_URI + " TEXT NOT NULL" +
                 ");");
-
-//        LogUtils.i("Alarms Table created");
     }
 
     public EmergencyContactDatabaseHelper(Context context) {

--- a/src/com/android/emergency/provider/EmergencyContactProvider.java
+++ b/src/com/android/emergency/provider/EmergencyContactProvider.java
@@ -26,22 +26,16 @@ import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
-//import android.content.UriMatcher;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
 import android.os.Build;
 import android.text.TextUtils;
-//import android.util.ArrayMap;
 
 import androidx.annotation.NonNull;
 
 import java.util.Objects;
-
-//import org.mockito.internal.matchers.Null;
-
-//import java.util.Map;
 
 public class EmergencyContactProvider extends ContentProvider {
 
@@ -93,24 +87,6 @@ public class EmergencyContactProvider extends ContentProvider {
 //        }
 
         return ret;
-    }
-
-    @Override
-    public String getType(@NonNull Uri uri) {
-//        int match = sURIMatcher.match(uri);
-//        switch (match) {
-//            case ALARMS:
-//                return "vnd.android.cursor.dir/alarms";
-//            case ALARMS_ID:
-//                return "vnd.android.cursor.item/alarms";
-//            case INSTANCES:
-//                return "vnd.android.cursor.dir/instances";
-//            case INSTANCES_ID:
-//                return "vnd.android.cursor.item/instances";
-//            default:
-//                throw new IllegalArgumentException("Unknown URI");
-//        }
-        return "oh boy";
     }
 
     @Override

--- a/src/com/android/emergency/provider/EmergencyContactProvider.java
+++ b/src/com/android/emergency/provider/EmergencyContactProvider.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.emergency.provider;
+
+import android.provider.ContactsContract;
+import static com.android.emergency.provider.EmergencyContactDatabaseHelper.EMERGENCY_CONTACTS_TABLE_NAME;
+import static com.android.emergency.provider.EmergencyContactDatabaseHelper.CONTACT_URI;
+
+import android.annotation.TargetApi;
+import android.content.ContentProvider;
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.Context;
+//import android.content.UriMatcher;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteQueryBuilder;
+import android.net.Uri;
+import android.os.Build;
+import android.text.TextUtils;
+//import android.util.ArrayMap;
+
+import androidx.annotation.NonNull;
+
+import java.util.Objects;
+
+//import org.mockito.internal.matchers.Null;
+
+//import java.util.Map;
+
+public class EmergencyContactProvider extends ContentProvider {
+
+    private EmergencyContactDatabaseHelper mOpenHelper;
+
+    public static final String CONTACT_URI_COLUMN = CONTACT_URI;
+    public static final Uri AUTHORITY_URI = Uri.parse("content://com.android.emergency.contacts");
+
+    public EmergencyContactProvider() {
+    }
+
+    @Override
+    @TargetApi(Build.VERSION_CODES.N)
+    public boolean onCreate() {
+        final Context context = getContext();
+        final Context storageContext;
+//        if (Utils.isNOrLater()) {
+//            // All N devices have split storage areas, but we may need to
+//            // migrate existing database into the new device encrypted
+//            // storage area, which is where our data lives from now on.
+        storageContext = context.createDeviceProtectedStorageContext();
+//            if (!storageContext.moveDatabaseFrom(context, ClockDatabaseHelper.DATABASE_NAME)) {
+//                LogUtils.wtf("Failed to migrate database: %s", ClockDatabaseHelper.DATABASE_NAME);
+//            }
+//        } else {
+//            storageContext = context;
+//        }
+
+        mOpenHelper = new EmergencyContactDatabaseHelper(storageContext);
+        return true;
+    }
+
+    @Override
+    public Cursor query(@NonNull Uri uri, String[] projectionIn, String selection,
+            String[] selectionArgs, String sort) {
+        SQLiteQueryBuilder qb = new SQLiteQueryBuilder();
+        SQLiteDatabase db = mOpenHelper.getReadableDatabase();
+
+        qb.setTables(EMERGENCY_CONTACTS_TABLE_NAME);
+        qb.appendWhere(ContactsContract.Contacts._ID + "=");
+        qb.appendWhere(Objects.requireNonNull(uri.getLastPathSegment()));
+
+        Cursor ret = qb.query(db, projectionIn, selection, selectionArgs, null, null, sort);
+
+//        if (ret == null) {
+//            LogUtils.e("Alarms.query: failed");
+//        } else {
+        ret.setNotificationUri(getContext().getContentResolver(), uri);
+//        }
+
+        return ret;
+    }
+
+    @Override
+    public String getType(@NonNull Uri uri) {
+//        int match = sURIMatcher.match(uri);
+//        switch (match) {
+//            case ALARMS:
+//                return "vnd.android.cursor.dir/alarms";
+//            case ALARMS_ID:
+//                return "vnd.android.cursor.item/alarms";
+//            case INSTANCES:
+//                return "vnd.android.cursor.dir/instances";
+//            case INSTANCES_ID:
+//                return "vnd.android.cursor.item/instances";
+//            default:
+//                throw new IllegalArgumentException("Unknown URI");
+//        }
+        return "oh boy";
+    }
+
+    @Override
+    public int update(@NonNull Uri uri, ContentValues values, String where, String[] whereArgs) {
+        int count;
+        String primaryKey = uri.getLastPathSegment();
+        if (TextUtils.isEmpty(where)) {
+            where = ContactsContract.Contacts._ID + "=" + primaryKey;
+        } else {
+            where = ContactsContract.Contacts._ID + "=" + primaryKey + " AND (" + where + ")";
+        }
+        SQLiteDatabase db = mOpenHelper.getWritableDatabase();
+        count = db.update(EMERGENCY_CONTACTS_TABLE_NAME, values, where, whereArgs);
+        notifyChange(getContext().getContentResolver(), uri);
+        return count;
+    }
+
+    @Override
+    public Uri insert(@NonNull Uri uri, ContentValues initialValues) {
+        long rowId;
+        SQLiteDatabase db = mOpenHelper.getWritableDatabase();
+        rowId = db.insert(EMERGENCY_CONTACTS_TABLE_NAME, null, initialValues);
+        Uri uriResult = ContentUris.withAppendedId(uri, rowId);
+        notifyChange(getContext().getContentResolver(), uriResult);
+        return uriResult;
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri, String where, String[] whereArgs) {
+        int count;
+        String primaryKey = uri.getLastPathSegment();
+        if (TextUtils.isEmpty(where)) {
+            where = ContactsContract.Contacts._ID + "=" + primaryKey;
+        } else {
+            where = ContactsContract.Contacts._ID + "=" + primaryKey + " AND (" + where + ")";
+        }
+        SQLiteDatabase db = mOpenHelper.getWritableDatabase();
+        count = db.delete(EMERGENCY_CONTACTS_TABLE_NAME, where, whereArgs);
+        notifyChange(getContext().getContentResolver(), uri);
+        return count;
+    }
+
+    /**
+     * Notify affected URIs of changes.
+     */
+    private void notifyChange(ContentResolver resolver, Uri uri) {
+        resolver.notifyChange(uri, null);
+    }
+}

--- a/src/com/android/emergency/provider/EmergencyContactProvider.java
+++ b/src/com/android/emergency/provider/EmergencyContactProvider.java
@@ -16,6 +16,7 @@
 
 package com.android.emergency.provider;
 
+import android.content.UriMatcher;
 import android.provider.ContactsContract;
 import static com.android.emergency.provider.EmergencyContactDatabaseHelper.EMERGENCY_CONTACTS_TABLE_NAME;
 import static com.android.emergency.provider.EmergencyContactDatabaseHelper.CONTACT_URI;
@@ -32,8 +33,10 @@ import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
 import android.os.Build;
 import android.text.TextUtils;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.Objects;
 
@@ -41,8 +44,22 @@ public class EmergencyContactProvider extends ContentProvider {
 
     private EmergencyContactDatabaseHelper mOpenHelper;
 
+    private static final int EMERGENCY_CONTACT_DATA = 1;
+    private static final int EMERGENCY_CONTACT_DATA_ID = 2;
+
+
     public static final String CONTACT_URI_COLUMN = CONTACT_URI;
-    public static final Uri AUTHORITY_URI = Uri.parse("content://com.android.emergency.contacts");
+
+    public static final String AUTHORITY = "com.android.emergency.contacts";
+    public static final Uri AUTHORITY_URI = Uri.parse("content://"+AUTHORITY);
+
+    private static final UriMatcher sURIMatcher = new UriMatcher(UriMatcher.NO_MATCH);
+    static {
+        sURIMatcher.addURI(AUTHORITY, "/data", EMERGENCY_CONTACT_DATA);
+        sURIMatcher.addURI(AUTHORITY, "/data/#", EMERGENCY_CONTACT_DATA_ID);
+    }
+
+    private static final String TAG = "EmergencyContactsProvider";
 
     public EmergencyContactProvider() {
     }
@@ -51,26 +68,21 @@ public class EmergencyContactProvider extends ContentProvider {
     @TargetApi(Build.VERSION_CODES.N)
     public boolean onCreate() {
         final Context context = getContext();
-        final Context storageContext;
-//        if (Utils.isNOrLater()) {
-//            // All N devices have split storage areas, but we may need to
-//            // migrate existing database into the new device encrypted
-//            // storage area, which is where our data lives from now on.
-        storageContext = context.createDeviceProtectedStorageContext();
-//            if (!storageContext.moveDatabaseFrom(context, ClockDatabaseHelper.DATABASE_NAME)) {
-//                LogUtils.wtf("Failed to migrate database: %s", ClockDatabaseHelper.DATABASE_NAME);
-//            }
-//        } else {
-//            storageContext = context;
-//        }
-
+        final Context storageContext = context.createDeviceProtectedStorageContext();
         mOpenHelper = new EmergencyContactDatabaseHelper(storageContext);
         return true;
     }
 
+
+
     @Override
     public Cursor query(@NonNull Uri uri, String[] projectionIn, String selection,
             String[] selectionArgs, String sort) {
+        int match = sURIMatcher.match(uri);
+        if (match != EMERGENCY_CONTACT_DATA && match != EMERGENCY_CONTACT_DATA_ID) {
+            throw new UnsupportedOperationException("Cannot query URI: " + uri);
+        }
+
         SQLiteQueryBuilder qb = new SQLiteQueryBuilder();
         SQLiteDatabase db = mOpenHelper.getReadableDatabase();
 
@@ -80,17 +92,35 @@ public class EmergencyContactProvider extends ContentProvider {
 
         Cursor ret = qb.query(db, projectionIn, selection, selectionArgs, null, null, sort);
 
-//        if (ret == null) {
-//            LogUtils.e("Alarms.query: failed");
-//        } else {
-        ret.setNotificationUri(getContext().getContentResolver(), uri);
-//        }
+        if (ret == null) {
+            Log.w(TAG, "Emergency Contact Query failed");
+        } else {
+            ret.setNotificationUri(getContext().getContentResolver(), uri);
+        }
 
         return ret;
     }
 
     @Override
+    public String getType(@NonNull Uri uri) {
+        int match = sURIMatcher.match(uri);
+        switch (match) {
+            case EMERGENCY_CONTACT_DATA:
+                return "vnd.android.cursor.dir/data";
+            case EMERGENCY_CONTACT_DATA_ID:
+                return "vnd.android.cursor.item/data";
+            default:
+                throw new IllegalArgumentException("Unknown URI: " + uri);
+        }
+    }
+
+    @Override
     public int update(@NonNull Uri uri, ContentValues values, String where, String[] whereArgs) {
+        int match = sURIMatcher.match(uri);
+        if (match != EMERGENCY_CONTACT_DATA_ID) {
+            throw new UnsupportedOperationException("Cannot update URI: " + uri);
+        }
+
         int count;
         String primaryKey = uri.getLastPathSegment();
         if (TextUtils.isEmpty(where)) {
@@ -106,6 +136,11 @@ public class EmergencyContactProvider extends ContentProvider {
 
     @Override
     public Uri insert(@NonNull Uri uri, ContentValues initialValues) {
+        int match = sURIMatcher.match(uri);
+        if (match != EMERGENCY_CONTACT_DATA_ID) {
+            throw new UnsupportedOperationException("Cannot insert URI: " + uri);
+        }
+
         long rowId;
         SQLiteDatabase db = mOpenHelper.getWritableDatabase();
         rowId = db.insert(EMERGENCY_CONTACTS_TABLE_NAME, null, initialValues);
@@ -116,6 +151,11 @@ public class EmergencyContactProvider extends ContentProvider {
 
     @Override
     public int delete(@NonNull Uri uri, String where, String[] whereArgs) {
+        int match = sURIMatcher.match(uri);
+        if (match != EMERGENCY_CONTACT_DATA_ID) {
+            throw new UnsupportedOperationException("Cannot delete URI: " + uri);
+        }
+
         int count;
         String primaryKey = uri.getLastPathSegment();
         if (TextUtils.isEmpty(where)) {


### PR DESCRIPTION
## Summary

When clicking into the Emergency Information in the lock screen in direct boot mode, emergency contacts will not be visible and cannot be called. 

## Problem Reproduction

1. Under settings → security/privacy → screen lock, set a PIN so the phone can be locked
2. Under contacts, create a contact with a name and a phone number
3. Under settings → emergency info, add a contact as an emergency contact
4. Reboot the device (do not unlock)
5. On the lock screen, click Emergency to open up a screen of the dialer
6. On the dialer screen, click the Owner / Emergency Info button twice to open up the list of emergency contacts, which will NOT display the previously set emergency contact.

## Expected Behaviour

Even before first unlock (when in Direct Boot mode), the emergency contact should be visible

## Cause

While the list of emergency contact URIs (e.g. content://com.android.contacts/data/4) is stored in device-encrypted storage (accessible in direct boot mode), the contact information, such as the name and phone number, is protected behind credential-encrypted storage (inaccessible in direct boot mode). This is a result of contacts being stored under ContactsProvider2, which is not Direct Boot Mode Aware. 

## Proposed Solution

We create a Direct Boot Mode aware EmergencyContactsProvider that stores a subset of contacts information specific to the emergency contacts set by the user. Now, instead of sending requests to the contacts provider, which will fail in direct boot mode, it will send requests to the emergency contacts provider, which will successfully provide information. Here are some specific details.

### Adding Emergency Contacts
Previously, adding a contact as an emergency contact would simply append the contact’s uri to the list of Contacts Apps Uris. Now, we fetch the information from the Contacts Provider, store it into the new Emergency Contacts Database, and append to the list of Emergency Contacts Apps URIs so that this information will be accessible in direct boot mode.

### Maintaining Consistency
When the phone has been unlocked, fetching the emergency contacts will query the contacts database to ensure that the emergency contacts database is up to date. reflecting changes to the contact information or deleting emergency contacts that reference a deleted contact.

## Testing

We have tested the following operations on a Pixel 6a running GrapheneOS 2025032100 with our changes:

- Adding an Emergency Contact
- Deleting an Emergency Contact
- Viewing the list of Emergency Contacts after rebooting the phone, in the lock screen
- Viewing the list of Emergency Contacts after unlocking the phone once, in the lock screen
- Viewing the list of Emergency Contacts in the settings application
- Adding multiple emergency contacts
- Adding contacts with multiple numbers or adding linked contacts
- Updating contact information and seeing the change reflected in emergency contacts
- Deleting a contact and seeing the emergency contact being deleted as well

## Remaining Issues

If a contact is deleted or has its information changed and the phone is rebooted, the list of emergency contacts will not reflect the change until 1. the phone is unlocked and 2. list of emergency contacts is viewed. A potential solution is that upon a deletion or modification, the contacts application can send an intent to the Emergency Info app, notifying the change.
